### PR TITLE
Fix `file.write` changing `\r\n` to `\r\r\n` on Windows

### DIFF
--- a/unwebpack_sourcemap.py
+++ b/unwebpack_sourcemap.py
@@ -183,7 +183,7 @@ class SourceMapExtractor(object):
                 write_path = self._get_sanitised_file_path(source)
                 if write_path is not None:
                     os.makedirs(os.path.dirname(write_path), mode=0o755, exist_ok=True)
-                    with open(write_path, 'w', encoding='utf-8', errors='ignore') as f:
+                    with open(write_path, 'w', encoding='utf-8', errors='ignore', newline='') as f:
                         print("Writing %s..." % os.path.basename(write_path))
                         f.write(content)
             else:

--- a/unwebpack_sourcemap.py
+++ b/unwebpack_sourcemap.py
@@ -171,23 +171,18 @@ class SourceMapExtractor(object):
         if len(map_object['sources']) != len(map_object['sourcesContent']):
             print("WARNING: sources != sourcesContent, filenames may not match content")
 
-        idx = 0
-        for source in map_object['sources']:
-            if idx < len(map_object['sourcesContent']):
-                path = source
-                content = map_object['sourcesContent'][idx]
-                idx += 1
+        for source, content in zip(map_object['sources'], map_object['sourcesContent']):
+            # remove webpack:// from paths
+            # and do some checks on it
+            write_path = self._get_sanitised_file_path(source)
+            if write_path is None:
+                print("ERROR: Could not sanitize path %s" % source)
+                continue
 
-                # remove webpack:// from paths
-                # and do some checks on it
-                write_path = self._get_sanitised_file_path(source)
-                if write_path is not None:
-                    os.makedirs(os.path.dirname(write_path), mode=0o755, exist_ok=True)
-                    with open(write_path, 'w', encoding='utf-8', errors='ignore', newline='') as f:
-                        print("Writing %s..." % os.path.basename(write_path))
-                        f.write(content)
-            else:
-                break
+            os.makedirs(os.path.dirname(write_path), mode=0o755, exist_ok=True)
+            with open(write_path, 'w', encoding='utf-8', errors='ignore', newline='') as f:
+                print("Writing %s..." % os.path.basename(write_path))
+                f.write(content)
 
     def _get_sanitised_file_path(self, sourcePath):
         """Sanitise webpack paths for separators/relative paths"""


### PR DESCRIPTION
`file.write()` automatically translates `\n` to the platform-specific line ending, which is `\r\n` (CRLF) for Windows.
But if the source file itself has Windows line endings, then they are incorrectly translated to `\r\r\n` while writing.  
`open()` does have a [`newline`  parameter](https://docs.python.org/3/library/functions.html#open-newline-parameter) that disables the automatic substitution when set to an empty string (`''`).

Also refactors the sources and sourceContent loop.